### PR TITLE
Accept up to 5 version components (was up to 4 before)

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+3.6.5 (2023-03-18)
+------------------
+
+* Accept up to 5 version components (was up to 4 before)
+
+* Report on ignored part of a loosely parsed ``Version``
+
+
 3.6.4 (2023-03-17)
 ------------------
 

--- a/src/runez/system.py
+++ b/src/runez/system.py
@@ -2039,7 +2039,7 @@ class _LazyCache:
             r"([-_.]?(?P<rel>post|rev|r)[-_.]?(?P<rel_num>\d*))?"
             r"([-_.]?(?P<dev>dev)[-_.]?(?P<dev_num>\d*))?"
             r"(\+(?P<local>[a-z0-9]+(?:[-_.][a-z0-9]+)*))?)"
-            r"(?P<rest>.*)"
+            r"(?P<ignored>.*)"
         )
 
     @cached_property

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -623,18 +623,18 @@ def test_unknown():
 @pytest.mark.parametrize(
     ("given_version", "expected"),
     [
-        ("1.2", (1, 2, 0, 0, 0)),
-        ("1.2rev5", (1, 2, 0, 0, 5)),
-        ("1.2r5.dev3", (1, 2, 0, 0, 5, ".dev.r", 0, 3)),
-        ("1.dev0", (1, 0, 0, 0, 0, ".dev", 0, 0)),
-        ("1.0.dev456", (1, 0, 0, 0, 0, ".dev", 0, 456)),
-        ("1.0a12", (1, 0, 0, 0, 0, "a", 12, 0)),
-        ("1.2.3rc12", (1, 2, 3, 0, 0, "rc", 12, 0)),
-        ("1.0a2.dev456", (1, 0, 0, 0, 0, "a.dev", 2, 456)),
-        ("1.0b2.post345", (1, 0, 0, 0, 345, "b.post", 2, 0)),
-        ("1.0b2.post345.dev456", (1, 0, 0, 0, 345, "b.dev.post", 2, 456)),
-        ("1.0rc1.dev456", (1, 0, 0, 0, 0, "rc.dev", 1, 456)),
-        ("1.0.post456.dev34", (1, 0, 0, 0, 456, ".dev.post", 0, 34)),
+        ("1.2", (1, 2, 0, 0, 0, 0)),
+        ("1.2rev5", (1, 2, 0, 0, 0, 5)),
+        ("1.2r5.dev3", (1, 2, 0, 0, 0, 5, ".dev.r", 0, 3)),
+        ("1.dev0", (1, 0, 0, 0, 0, 0, ".dev", 0, 0)),
+        ("1.0.dev456", (1, 0, 0, 0, 0, 0, ".dev", 0, 456)),
+        ("1.0a12", (1, 0, 0, 0, 0, 0, "a", 12, 0)),
+        ("1.2.3rc12", (1, 2, 3, 0, 0, 0, "rc", 12, 0)),
+        ("1.0a2.dev456", (1, 0, 0, 0, 0, 0, "a.dev", 2, 456)),
+        ("1.0b2.post345", (1, 0, 0, 0, 0, 345, "b.post", 2, 0)),
+        ("1.0b2.post345.dev456", (1, 0, 0, 0, 0, 345, "b.dev.post", 2, 456)),
+        ("1.0rc1.dev456", (1, 0, 0, 0, 0, 0, "rc.dev", 1, 456)),
+        ("1.0.post456.dev34", (1, 0, 0, 0, 0, 456, ".dev.post", 0, 34)),
     ]
 )
 def test_pep_sample(given_version, expected):
@@ -651,11 +651,13 @@ def test_pep_sample(given_version, expected):
 def test_version():
     loose = Version("v1.0.dirty", strict=False)
     assert loose.is_valid
+    assert loose.ignored == ".dirty"
     assert str(loose) == "1.0"
 
     invalid = Version("v1.0.dirty", strict=True)
     assert not invalid.is_valid
     assert str(invalid) == "v1.0.dirty"
+    assert invalid.ignored == ".dirty"
     assert loose > invalid
 
     dev101 = Version("0.0.1.dev101")
@@ -689,14 +691,14 @@ def test_version():
     assert not foo.prerelease
     assert foo.major is None
 
-    bogus = Version("1.2.3.4.5")
-    assert str(bogus) == "1.2.3.4.5"
+    bogus = Version("1.2.3.4.5.6")
+    assert str(bogus) == "1.2.3.4.5.6"
     assert not bogus.is_valid
     assert not bogus.components
     assert not bogus.prerelease
 
     v1 = Version("1")
-    assert v1.components == (1, 0, 0, 0, 0)
+    assert v1.components == (1, 0, 0, 0, 0, 0)
     assert str(v1) == "1"
     assert v1.mm == "1.0"
     assert empty < v1
@@ -713,7 +715,7 @@ def test_version():
     # All versions are bigger than anything not parsing to a valid version
     assert v1 > ""
     assert v1 > []
-    assert v1 > [5, 2, 3, 4, 5]
+    assert v1 > [5, 2, 3, 4, 5, 6]
 
     v1foo = Version("1foo")  # Ignore additional text
     assert v1 == v1foo

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -607,8 +607,10 @@ def check_terminal_program_name(*names):
         assert TerminalProgram.known_terminal(name) == name
 
 
-def test_terminal():
+def test_terminal(monkeypatch):
     assert TerminalProgram.known_terminal("termin") is None
+    monkeypatch.delenv("COLUMNS", raising=False)
+    monkeypatch.delenv("LINES", raising=False)
     check_terminal_program_name(
         "alacritty",
         "eterm",
@@ -638,14 +640,14 @@ def test_terminal():
             assert t.get_columns() == 12
             assert t.get_lines() == 12
 
-    with patch.dict(os.environ, {"LC_TERMINAL": "foo", "LC_TERMINAL_VERSION": "2"}):
+    with patch.dict(os.environ, {"LC_TERMINAL": "foo", "LC_TERMINAL_VERSION": "2", "TERM": "screen-256color"}):
         t = TerminalInfo()
         p = t.term_program
-        assert str(p) == "foo v2"
+        assert str(p) == "foo v2 screen-256color"
         p.extra_info = None
-        assert str(p) == "foo"
+        assert str(p) == "foo screen-256color"
 
-    with patch.dict(os.environ, {"LC_TERMINAL": "", "TERM_PROGRAM": ""}):
+    with patch.dict(os.environ, {"LC_TERMINAL": "", "TERM_PROGRAM": "", "TERM": ""}):
         # Simulate a known terminal
         ps = runez.PsInfo()
         ps.followed_parent.cmd = "/dev/null/tilix"


### PR DESCRIPTION
* Accept up to 5 version components (was up to 4 before)

* Report on ignored part of a loosely parsed ``Version``
