### PR TITLE
Enabled more lint rules, notably flake8-pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,22 +26,21 @@ extend-select = [
     "INT", # flake8-gettext
     "PGH", # pygrep-hooks
     "PIE", # flake8-pie
-#    "PT", # flake8-pytest
-#    "PYI", # flake8-pyi
-#    "Q",   # flake8-quotes
-#    "RSE", # flake8-raise
+    "PT", # flake8-pytest
+    "PYI", # flake8-pyi
+    "Q",   # flake8-quotes
+    "RSE", # flake8-raise
 #    "RET", # flake8-return
-##    "RUF", # ruff-specific
-##    "S",   # flake8-bandit
-##    "SIM", # flake8-simplify
-##    "SLF", # flake8-self
-#    "SLOT", # flake8-slots
-#    "T10", # flake8-debugger
-#    "TID", # flake8-tidy-imports
-#    "TCH", # flake8-type-checking
-##    "TD", # flake8-todos
-##    "TRY", # tryceratops
-#    "W",   # pycodestyle warnings
+    "RUF", # ruff-specific
+#    "SIM", # flake8-simplify
+#    "SLF", # flake8-self
+    "SLOT", # flake8-slots
+    "T10", # flake8-debugger
+    "TID", # flake8-tidy-imports
+    "TCH", # flake8-type-checking
+    "TD", # flake8-todos
+#    "TRY", # tryceratops
+    "W",   # pycodestyle warnings
 ]
 
 [tool.ruff.lint.isort]

--- a/src/runez/__main__.py
+++ b/src/runez/__main__.py
@@ -93,7 +93,7 @@ def cmd_import_speed():
 
     table = PrettyTable("Module,-X cumulative,Elapsed,Vs fastest,Note", border=args.border)
     table.header[3].align = "center"
-    mid = _get_mid(times) or 0
+    mid = _get_mid(times)
     for t in sorted(times):
         if t.cumulative is None:
             c = e = f = None
@@ -200,6 +200,8 @@ def _get_mid(times):
     if times:
         times = sorted(times, key=lambda x: -x.elapsed)  # Don't fail if no elapsed available
         return times[int(len(times) / 2)].elapsed
+
+    return 0
 
 
 def main():

--- a/src/runez/ascii.py
+++ b/src/runez/ascii.py
@@ -99,7 +99,7 @@ class AsciiAnimation:
     @classmethod
     def af_fill(cls):
         """Bar growing/shrinking vertically, then horizontally"""
-        return AsciiFrames([" "] + cls.symmetrical(list("▁▂▃▄▅▆▇█")) + [" "] + cls.symmetrical(list("▏▎▍▌▋▊▉")))
+        return AsciiFrames([" ", cls.symmetrical(list("▁▂▃▄▅▆▇█")), " ", cls.symmetrical(list("▏▎▍▌▋▊▉"))])
 
     @classmethod
     def af_fill2(cls):

--- a/src/runez/click.py
+++ b/src/runez/click.py
@@ -288,11 +288,7 @@ def option(func, *args, **attrs):
 
         attrs.setdefault("required", False)
         if not name.startswith("-"):
-            if negatable:
-                name = "--%s/--no-%s" % (name, name)
-
-            else:
-                name = "--%s" % name
+            name = f"--{name}/--no-{name}" if negatable else f"--{name}"
 
         return click.option(name, *args, **attrs)(f)
 
@@ -376,7 +372,7 @@ def protected_main(main, debug_stacktrace=False, no_stacktrace=None):
 def _auto_complete_callback(attrs, func):
     if not attrs.get("expose_value", True) and attrs.get("callback") is None:
 
-        def _callback(ctx, param, value):
+        def _callback(_ctx, _param, value):
             value = func(value)
             return value
 
@@ -408,7 +404,7 @@ class _ConfigOption:
         config.add(provider)
         return values
 
-    def __call__(self, ctx, param, value):
+    def __call__(self, _ctx, _param, value):
         c = runez.config.Configuration()
         self._add_dict(c, self.name, self._get_values(value))
 

--- a/src/runez/colors/__init__.py
+++ b/src/runez/colors/__init__.py
@@ -175,16 +175,8 @@ class Renderable:
         >>> runez.blue("foo")
         'foo'
         """
-        if size:
-            text = short(text, size=size)
-
-        else:
-            text = stringified(text)
-
-        if not text:
-            return ""
-
-        return self.rendered(text)
+        text = short(text, size=size) if size else stringified(text)
+        return self.rendered(text) if text else ""
 
     def rendered(self, text):
         return text

--- a/src/runez/config.py
+++ b/src/runez/config.py
@@ -124,7 +124,7 @@ class Configuration:
             front (bool): If True, add provider to front of list
         """
         if not isinstance(provider, ConfigProvider):
-            raise ValueError("Invalid config provider '%s'" % provider)
+            raise TypeError("Invalid config provider '%s'" % provider)
 
         i = self.provider_id_slot(provider)
         if i is not None:

--- a/src/runez/conftest.py
+++ b/src/runez/conftest.py
@@ -3,7 +3,7 @@ Import this only from your test cases
 
 Example:
 
-    from runez.conftest import cli, isolated_log_setup, temp_folder
+    from runez.conftest import cli, temp_folder
 """
 
 import logging
@@ -65,9 +65,6 @@ def exception_raiser(exc=Exception):
         if isinstance(exc, str):
             raise Exception(exc)
 
-        if isinstance(exc, type) and issubclass(exc, BaseException):
-            raise exc()
-
         raise exc
 
     return _raise
@@ -85,7 +82,7 @@ def patch_env(monkeypatch, clear=True, uppercase=True, **values):
         values = {k.upper(): v for k, v in values.items()}
 
     if clear:
-        for k in os.environ.keys():
+        for k in os.environ:
             if k not in values:
                 monkeypatch.delenv(k)
 
@@ -149,7 +146,7 @@ class IsolatedLogSetup:
                 os.chdir(self.old_cwd)
 
 
-@pytest.fixture
+@pytest.fixture()
 def cli():
     """Convenience fixture for click CLI testing.
 
@@ -173,9 +170,6 @@ def cli():
         yield ClickRunner(context=context)
 
 
-# This just allows to get auto-complete to work in PyCharm
-cli = cli  # type: ClickRunner
-
 # Comes in handy for click apps with only one main entry point
 cli.default_main = None
 
@@ -183,28 +177,16 @@ cli.default_main = None
 cli.context = TempFolder
 
 
-@pytest.fixture
-def isolated_log_setup():
-    """Log settings restored"""
-    with IsolatedLogSetup() as tmp:
-        yield tmp
-
-
-@pytest.fixture
+@pytest.fixture()
 def logged():
     with CaptureOutput(seed_logging=True) as logged:
         yield logged
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_folder():
     with TempFolder() as tmp:
         yield tmp
-
-
-# This just allows to get auto-complete to work in PyCharm
-logged = logged  # type: TrackedOutput
-temp_folder = temp_folder  # type: str
 
 
 class WrappedHandler(_pytest.logging.LogCaptureHandler):
@@ -263,7 +245,7 @@ class ClickRunner:
 
     args: list = None  # Arguments used in last run()
     exit_code: int = None  # Exit code of last run()
-    logged: TrackedOutput = None  # Captured log from last run()
+    logged: TrackedOutput  # Captured log from last run()
     main: callable = None  # Optional, override default_main for this runner instance
     trace: bool = None  # Optional, enable trace logging for this runner instance
 

--- a/src/runez/convert.py
+++ b/src/runez/convert.py
@@ -5,6 +5,7 @@ This is module should not import any other runez module, it's the lowest on the 
 import pathlib
 import re
 from collections import defaultdict
+from typing import ClassVar
 
 from runez.system import _R, flattened, joined, stringified
 
@@ -228,9 +229,9 @@ def identifiers(text):
 class Pluralizer:
     """Quick heuristic to pluralize most common english words"""
 
-    letter_based = {"s": "ses", "x": "xes", "y": "ies"}
-    suffix_based = {"ch": "ches", "fe": "ves", "man": "men", "sh": "shes"}
-    word_based = {"child": "children", "person": "people"}
+    letter_based: ClassVar = {"s": "ses", "x": "xes", "y": "ies"}
+    suffix_based: ClassVar = {"ch": "ches", "fe": "ves", "man": "men", "sh": "shes"}
+    word_based: ClassVar = {"child": "children", "person": "people"}
 
     @classmethod
     def find_letter_based(cls, singular):
@@ -362,13 +363,12 @@ def _int_from_text(text, base=None, default=None):
         return int(text, base=base)
 
     except ValueError:
-        if base is None:
-            if len(text) >= 3 and text[0] == "0":
-                if text[1] == "o":
-                    return _int_from_text(text, base=8, default=default)
+        if base is None and len(text) >= 3 and text[0] == "0":
+            if text[1] == "o":
+                return _int_from_text(text, base=8, default=default)
 
-                if text[1] == "x":
-                    return _int_from_text(text, base=16, default=default)
+            if text[1] == "x":
+                return _int_from_text(text, base=16, default=default)
 
     return default
 

--- a/src/runez/date.py
+++ b/src/runez/date.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from typing import ClassVar
 
 from runez.convert import _float_from_text
 from runez.system import _R, stringified, UNSET
@@ -23,9 +24,9 @@ class timezone(datetime.tzinfo):
     Supported timezone are simply: UTC, and explicit offsets like +01:00
     """
 
-    __singletons = {}  # Cached timezone objects per offset
+    __singletons: ClassVar = {}  # Cached timezone objects per offset
 
-    def __new__(cls, offset, name=None):
+    def __new__(cls, offset, *_):
         existing = cls.__singletons.get(offset)
         if existing is None:
             existing = super().__new__(cls)
@@ -56,13 +57,13 @@ class timezone(datetime.tzinfo):
         if isinstance(other, datetime.tzinfo):
             return self.offset == other.utcoffset(datetime.datetime.now(tz=UTC))
 
-    def utcoffset(self, dt):
+    def utcoffset(self, *_):
         return self.offset
 
-    def tzname(self, dt):
+    def tzname(self, *_):
         return self.name
 
-    def dst(self, dt):
+    def dst(self, *_):
         return self.offset
 
 

--- a/src/runez/heartbeat.py
+++ b/src/runez/heartbeat.py
@@ -19,6 +19,7 @@ Usage:
 
 import threading
 import time
+from typing import ClassVar, List
 
 from runez.system import LOG, ltattr
 
@@ -70,7 +71,7 @@ class Heartbeat:
     - refreshing data from a remote server
     """
 
-    tasks = []  # type: list # of task, to be periodically called
+    tasks: ClassVar[List[HeartbeatTask]] = []  # of task, to be periodically called
 
     _lock = threading.Lock()
     _thread = None  # Background daemon thread used to periodically execute the tasks

--- a/src/runez/http.py
+++ b/src/runez/http.py
@@ -29,6 +29,7 @@ import re
 import sys
 import urllib.parse
 from pathlib import Path
+from typing import ClassVar
 
 from runez.file import checksum, decompress, delete, ensure_folder, TempFolder, to_path
 from runez.system import _R, abort, DEV, find_caller, joined, short, stringified, SYS_INFO, UNSET
@@ -60,7 +61,7 @@ class CacheWrapper:
     """
 
     base_location = "~/.cache/{program_name}"
-    cachable_methods = {"GET": True, "POST": True}  # By default, cache only these REST methods
+    cachable_methods = ("GET", "POST")  # By default, cache only these REST methods
     default_expire = "1h"  # 1 hour
     size_limit = "2g"  # 2 GB
 
@@ -109,7 +110,6 @@ class CacheWrapper:
             size_limit (int | None): Max size in bytes for this cache
         """
         self.base_location = base_location
-        self.cachable_methods = dict(self.cachable_methods)
         self.default_expire = _R.lc.rm.to_seconds(default_expire)
         self.size_limit = _R.lc.rm.to_bytesize(size_limit)
         self.cache_backend = cache_backend
@@ -138,7 +138,7 @@ class CacheWrapper:
         Returns:
             (bool): True if this REST method call should be cached
         """
-        return self.cachable_methods.get(method)
+        return method in self.cachable_methods
 
     def delete(self, cache_key):
         """
@@ -394,7 +394,7 @@ class MockedHandlerStack:
 
 
 class MockCentral:
-    _stacks = {}
+    _stacks: ClassVar = {}
 
     @classmethod
     def get_stack(cls, handler, key):

--- a/src/runez/program.py
+++ b/src/runez/program.py
@@ -149,14 +149,21 @@ class PsInfo:
 
     def parent_list(self, follow=True):
         """
-        Args:
-            follow (bool): If True, try and follow special processes like tmux
+        Parameters
+        ----------
+        follow: bool
+            If True, try and follow special processes like tmux
 
-        Returns:
-            (list[PsInfo]): List of parent processes
+        Returns
+        -------
+        list[PsInfo]
+            List of parent processes
         """
         p = self.followed_parent if follow else self.parent
-        return [p] + p.parent_list(follow=follow) if p else []
+        if not p:
+            return []
+
+        return [p, *p.parent_list(follow=follow)]
 
 
 def auto_shellify(args):
@@ -341,7 +348,7 @@ def run(
 
         fatal = False  # pragma: no cover, non-fatal mode in background process (there is no more console etc to report anything)
 
-    with _WrappedArgs([full_path] + args) as wrapped_args:
+    with _WrappedArgs([full_path, *args]) as wrapped_args:
         try:
             p, out, err = _run_popen(wrapped_args, popen_args, passthrough, fatal, stdout, stderr)
             result.output = decode(out, strip=strip)
@@ -730,7 +737,7 @@ class _WrappedArgs:
             with open(wrapper, "wt") as fh:
                 fh.write('exec "$@"\n')
 
-            args = ["/bin/sh", wrapper] + args
+            args = ["/bin/sh", wrapper, *args]
 
         return args
 

--- a/src/runez/render.py
+++ b/src/runez/render.py
@@ -477,7 +477,7 @@ class _PTBorderChars(Slotted):
         return super()._values_from_object(obj)
 
     def __repr__(self):
-        return self.represented_values(delimiter="", operator="", name_formatter=lambda x: "")
+        return self.represented_values(delimiter="", operator="", name_formatter=lambda _: "")
 
 
 class _PTTable:

--- a/src/runez/schema.py
+++ b/src/runez/schema.py
@@ -124,7 +124,6 @@ class Any:
 
     def _problem(self, value):
         """To be re-defined by descendants, `value` is never `None`"""
-        return None
 
     def converted(self, value):
         """
@@ -249,6 +248,7 @@ class Enum(Any):
         """
         if hasattr(values, "split"):
             values = values.split()
+
         self.values = set(values)
         super().__init__(default=default)
 
@@ -332,11 +332,7 @@ class Struct(Any):
 
     def __eq__(self, other):
         if other is not None and other.__class__ is self.__class__:
-            for name in self.meta.attributes:
-                if not hasattr(other, name) or getattr(self, name) != getattr(other, name):
-                    return False
-
-            return True
+            return not any(not hasattr(other, x) or getattr(self, x) != getattr(other, x) for x in self.meta.attributes)
 
     def __ne__(self, other):
         return not (self == other)

--- a/src/runez/thread.py
+++ b/src/runez/thread.py
@@ -43,8 +43,8 @@ class ThreadLocalSingleton:
     def __new__(cls, *positional, **named):
         # We could do singleton by combination of args, but outcome of that could be hard to grok for users
         # Not sure if there's a good use case for this (one where gotcha-factor is much lower than added value)
-        assert not positional and not named, "Current limitation: only classes that can be created without args are supported for now"
-
+        assert not positional, "Current limitation: positional args are not supported"
+        assert not named, "Current limitation: named args are not supported"
         key = "_ts%s.%s" % (cls.__module__, cls.__name__)
         existing = getattr(THREAD_LOCAL, key, None)
         if existing is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 import runez
 from runez.__main__ import main
-from runez.conftest import cli, isolated_log_setup, IsolatedLogSetup, logged, temp_folder
+from runez.conftest import cli, IsolatedLogSetup, logged, temp_folder
 from runez.file import readlines
 from runez.http import GlobalHttpCalls
 from runez.logsetup import LogManager
@@ -18,7 +18,7 @@ runez.serialize.set_default_behavior(strict=False, extras=True)
 
 
 # This is here only to satisfy flake8, mentioning the imported fixtures so they're not declared "unused"
-assert all(s for s in [cli, isolated_log_setup, logged, temp_folder])
+assert all(s for s in [logged, temp_folder])
 
 
 class TempLog:
@@ -36,8 +36,7 @@ class TempLog:
 
     @property
     def logfile(self):
-        if LogManager.file_handler:
-            return short(LogManager.file_handler.baseFilename)
+        return short(LogManager.file_handler.baseFilename) if LogManager.file_handler else None
 
     def pop(self):
         content = ""
@@ -79,7 +78,7 @@ class TempLog:
         return len(self.tracked)
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_log():
     with IsolatedLogSetup():
         with CaptureOutput() as tracked:

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -140,11 +140,10 @@ def test_command_with_stderr(cli):
 
 def sample_config(**attrs):
     attrs.setdefault("tracer", print)
-    c = runez.click._ConfigOption(attrs)
-    return c
+    return runez.click._ConfigOption(attrs)
 
 
-def test_config(isolated_log_setup, logged, monkeypatch):
+def test_config(logged, monkeypatch):
     # sys.argv is used as env var prefix when env=True is used
     runez.log.enable_trace(True)
     config = sample_config(env=True)(None, None, "")
@@ -220,7 +219,8 @@ def test_group(cli):
     assert cli.succeeded
     assert "Repeat provided text" in cli.logged
     assert "This part will be an epilog" in cli.logged
-    assert "Changed folder to foo" in cli.logged  # TODO: correct it so it doesn't get logged twice
+    assert "Changed folder to foo" in cli.logged
+
     # Verify that current folder was restored
     assert cli.context == os.getcwd()
     assert runez.system.AbortException is not SystemExit

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -21,7 +21,7 @@ def test_colors():
     msg2 = runez.colored("hi", "dim")
     assert msg1 == msg2
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown color"):
         runez.color.cast_style("foo")
 
     assert not runez.color.is_coloring()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,55 +50,54 @@ def test_no_implementation():
     assert str(config) == "empty"
     assert config.get("anything") is None
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="Invalid config provider"):
         config.add(object())
 
     assert str(config) == "empty"
 
 
-def test_samples(isolated_log_setup):
+def test_samples(temp_log):
     runez.log.setup()
     runez.log.enable_trace(True)
-    with runez.CaptureOutput() as output:
-        config = runez.config.Configuration()
-        config.add(runez.config.PropsfsProvider(SAMPLES))
-        assert str(config) == "propsfs"
-        assert "Adding config provider propsfs" in output.pop()
+    config = runez.config.Configuration()
+    config.add(runez.config.PropsfsProvider(SAMPLES))
+    assert str(config) == "propsfs"
+    assert "Adding config provider propsfs" in temp_log.tracked.pop()
 
-        assert config.get_str("non-existent") is None
-        assert not output
+    assert config.get_str("non-existent") is None
+    assert not temp_log.tracked
 
-        assert config.get_str("some-string") == "hello there"
-        assert "Using some-string='hello there' from propsfs" in output.pop()
+    assert config.get_str("some-string") == "hello there"
+    assert "Using some-string='hello there' from propsfs" in temp_log.tracked.pop()
 
-        assert config.get_int("some-string") is None
-        assert config.get_float("some-string") is None
-        assert config.get_bool("some-string") is False
-        assert config.get_bytesize("some-string") is None
+    assert config.get_int("some-string") is None
+    assert config.get_float("some-string") is None
+    assert config.get_bool("some-string") is False
+    assert config.get_bytesize("some-string") is None
 
-        assert config.get_str("some-string", default="foo") == "hello there"
-        assert config.get_int("some-string", default=5) == 5
-        assert config.get_float("some-string", default=5.1) == 5.1
-        assert config.get_bool("some-string", default=False) is False
-        assert config.get_bytesize("some-string", default=5) == 5
+    assert config.get_str("some-string", default="foo") == "hello there"
+    assert config.get_int("some-string", default=5) == 5
+    assert config.get_float("some-string", default=5.1) == 5.1
+    assert config.get_bool("some-string", default=False) is False
+    assert config.get_bytesize("some-string", default=5) == 5
 
-        assert config.get_str("some-int") == "123"
-        assert config.get_int("some-int") == 123
-        assert config.get_float("some-int") == 123
-        assert config.get_bool("some-int") is True
-        assert config.get_bytesize("some-int") == 123
+    assert config.get_str("some-int") == "123"
+    assert config.get_int("some-int") == 123
+    assert config.get_float("some-int") == 123
+    assert config.get_bool("some-int") is True
+    assert config.get_bytesize("some-int") == 123
 
-        assert config.get_json("sample.json") == {"some-key": "some-value", "some-int": 51}
-        assert config.get_json("some-string") is None
-        assert config.get_json("some-string", default={"a": "b"}) == {"a": "b"}
-        assert config.get_json("some-string", default='{"a": "b"}') == {"a": "b"}
+    assert config.get_json("sample.json") == {"some-key": "some-value", "some-int": 51}
+    assert config.get_json("some-string") is None
+    assert config.get_json("some-string", default={"a": "b"}) == {"a": "b"}
+    assert config.get_json("some-string", default='{"a": "b"}') == {"a": "b"}
 
-        additional = runez.config.DictProvider({"some-string": "foo", "x": "y"})
-        config.add(additional, front=True)
+    additional = runez.config.DictProvider({"some-string": "foo", "x": "y"})
+    config.add(additional, front=True)
 
-        values = config.values
-        assert len(values) == 4
-        assert values["sample.json"]
-        assert values["some-int"] == "123"
-        assert values["some-string"] == "foo"
-        assert values["x"] == "y"
+    values = config.values
+    assert len(values) == 4
+    assert values["sample.json"]
+    assert values["some-int"] == "123"
+    assert values["some-string"] == "foo"
+    assert values["x"] == "y"

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -72,7 +72,7 @@ def test_epoch():
 
 def test_represented_duration():
     assert runez.represented_duration(None) == "None"
-    assert runez.represented_duration("foo") == "foo"  # noqa, verifiy non-duration left as-is...
+    assert runez.represented_duration("foo") == "foo"  # verify non-duration left as-is...
     assert runez.represented_duration(runez.UNSET) == "UNSET"
 
     assert runez.represented_duration(0) == "0 seconds"
@@ -203,7 +203,7 @@ def test_to_seconds():
     assert runez.to_seconds("1 m2s") is None
     assert runez.to_seconds("1m 2") is None
     assert runez.to_seconds("1month") is None
-    assert runez.to_seconds([1]) is None  # noqa, verify no crash on bogus type
+    assert runez.to_seconds([1]) is None  # verify no crash on bogus type
 
     assert runez.to_seconds("") == 0
     assert runez.to_seconds(5) == 5

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -5,15 +5,17 @@ from runez.heartbeat import DEFAULT_FREQUENCY, Heartbeat, HeartbeatTask
 
 class Counter(HeartbeatTask):
     count = None
-    crash = False
+    crash = None
 
     def execute(self):
         if self.count is None:
             self.count = 1
+
         else:
             self.count += 1
-        if self.crash:
-            raise Exception("oops, just crashed")
+
+        if self.crash is not None:
+            raise self.crash
 
 
 def do_nothing():
@@ -23,7 +25,7 @@ def do_nothing():
 def test_heartbeat():
     task = Counter()
     crash = Counter(name="crasher")
-    crash.crash = True
+    crash.crash = ValueError("oops, just crashed")
 
     # Exercise case with no tasks
     assert len(Heartbeat.tasks) == 0

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -24,17 +24,18 @@ def test_auto_import_siblings():
     # Check that none of these invocations raise an exception
     caller = runez.system.find_caller(depth=1)  # Finds this test as caller
     assert str(caller) == "tests.test_inspector.test_auto_import_siblings"
+
+    # Pretend we're calling auto_import_siblings() from a __main__
+    caller.module_name = "__main__"
+    assert caller.is_main
     with pytest.raises(ImportError):
-        # Pretend we're calling auto_import_siblings() from a __main__
-        caller.module_name = "__main__"
-        assert caller.is_main
         auto_import_siblings(caller=caller)
 
+    # Pretend caller doesn't have a __package__
+    caller.package_name = None
+    caller.module_name = "foo"
+    assert not caller.is_main
     with pytest.raises(ImportError):
-        # Pretend caller doesn't have a __package__
-        caller.package_name = None
-        caller.module_name = "foo"
-        assert not caller.is_main
         auto_import_siblings(caller=caller)
 
     py_file_count = len(list(importable_test_py_files(runez.DEV.tests_folder))) - 1  # Remove one to not count tests/__init__.py itself

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -35,9 +35,8 @@ def test_with_tty(monkeypatch, logged):
             assert ask_once("test", "bar", base=tmp) == expected  # Ask a 2nd time, same response
 
             # Verify that if `serializer` returns None, value is not returned/stored
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match="Invalid value provided for test-invalid"):
                 ask_once("test-invalid", "invalid", base=tmp, serializer=custom_serializer, fatal=True, logger=None)
-            assert "Invalid value provided for test-invalid" in str(exc)
             assert not os.path.exists("test-invalid.json")
 
             # Same, but don't raise exception (returns default)
@@ -45,13 +44,11 @@ def test_with_tty(monkeypatch, logged):
             assert not logged  # Traced by default
 
             # Simulate no value provided
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match="No value provided"):
                 ask_once("test-invalid", "", base=tmp, serializer=custom_serializer, fatal=True)
-            assert "No value provided" in str(exc)
             assert "No value provided" in logged.pop()  # Logged if fatal=True
 
     with patch("runez.prompt.input", side_effect=KeyboardInterrupt):
         # Simulate CTRL+C
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(Exception, match="Cancelled by user"):
             ask_once("test2", "test2", base=tmp, serializer=custom_serializer, fatal=True)
-        assert "Cancelled by user" in str(exc)

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -164,7 +164,7 @@ def test_depot_folder(temp_folder):
     mk_python("8.5.7")
     runez.symlink(".pyenv/versions/8.5.6/bin/python", "python8.5", logger=None)
     runez.symlink("python8.5", "python", logger=None)
-    depot = PythonDepot(".")
+    depot = PythonDepot(temp_folder)
     assert len(depot.available_pythons) == 1
     python = depot.find_python(None)
     assert str(python) == "python8.5 [8.5.6]"
@@ -175,14 +175,14 @@ def test_depot_folder(temp_folder):
     assert str(depot.find_python("8.5.7")) == "8.5.7 [not available]"
 
 
-def test_depot_path(temp_folder):
+def test_depot_path():
     depot = PythonDepot("PATH")
     assert depot.available_pythons
     assert depot.preferred_python is None
     assert depot.find_python(None) is depot.invoker
 
 
-def test_empty_depot(temp_folder):
+def test_empty_depot():
     depot = PythonDepot()
     assert depot.representation() == "No PythonDepot locations configured"
     assert not depot.available_pythons
@@ -228,7 +228,7 @@ def test_inspect():
     assert '"version":' in r.output
 
 
-def test_invoker(monkeypatch):
+def test_invoker():
     import runez.pyenv
 
     invoker = runez.SYS_INFO.invoker_python
@@ -674,8 +674,7 @@ def test_version_comparison():
     assert v20d.suffix == "dev"
 
     # Verify that numerical comparison takes place (not alphanumeric)
-    assert None < v12  # For total ordering
-    assert v12 > None
+    assert v12 > None  # For total ordering
     assert v12 == "1.2.3"
     assert v12 == [1, 2, 3]
     assert v12 == (1, 2, 3)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -18,11 +18,11 @@ def test_align():
     assert Align.cast(None, default=Align.right) is Align.right
     assert Align.cast(Align.right) is Align.right
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid horizontal alignment 'foo'"):
         assert Align.cast("foo")
 
-    with pytest.raises(ValueError):
-        assert Align.cast("foo", "foo")
+    with pytest.raises(ValueError, match="Invalid default horizontal alignment"):
+        assert Align.cast("foo", "bar")
 
     assert Align.center("foo", 5) == " foo "
     assert Align.left("foo", 5) == "foo  "
@@ -117,8 +117,8 @@ def test_header():
 
 
 def test_pretty_table():
-    with pytest.raises(ValueError):
-        PrettyTable(object)  # Invalid header
+    with pytest.raises(ValueError, match="Invalid header"):
+        PrettyTable(object)
 
     t = PrettyTable()
     assert len(t.header) == 0

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -342,9 +342,10 @@ def test_slotted(logged):
     assert se.name == "foo"
     assert se.to_dict() == {"name": "foo"}
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match="Extra content given for SlottedExample: foo"):
         SlottedExample.from_dict({"foo": "bar"})
-    assert str(e.value) == "Extra content given for SlottedExample: foo"
+
+    assert not logged
 
 
 def test_to_dict(temp_folder):

--- a/tests/test_slotted.py
+++ b/tests/test_slotted.py
@@ -85,11 +85,11 @@ def test_adapted_properties():
 
     s1a.prop1c = None  # caster should accept None
     assert s1a.prop1c is None
-    with pytest.raises(ValueError):  # but anything other than None must be an int
+    with pytest.raises(ValueError, match="invalid literal for int"):  # but anything other than None must be an int
         s1a.prop1c = "foo"
     assert s1a.prop1c is None
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="not 'NoneType'"):
         s1a.prop1d = None  # prop1d uses type=int, and int() does not accept None
 
     # prop3 and prop4 insist on ints
@@ -98,7 +98,7 @@ def test_adapted_properties():
     assert s1a.prop3 == 30
     assert s1a.prop4 == 40
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid literal for int"):
         s1a.prop3 = "foo"
 
     # Verify properties stay bound to their object
@@ -118,9 +118,8 @@ def test_insights():
         name = "testing"
         age = 10
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TypeError, match="should be instance"):
         runez.Slotted.fill_attributes(Foo, {})
-    assert "should be instance" in str(exc)
 
     foo = Foo()
     assert foo.name == "testing"
@@ -130,9 +129,8 @@ def test_insights():
     runez.Slotted.fill_attributes(foo, {"name": runez.UNSET})
     assert foo.name == "testing"  # back to class default
 
-    with pytest.raises(AttributeError) as exc:
+    with pytest.raises(AttributeError, match="Unknown Foo key 'bar'"):
         runez.Slotted.fill_attributes(foo, {"bar": 5})
-    assert "Unknown Foo key 'bar'" in str(exc)
 
 
 def test_slotted():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -27,7 +27,7 @@ def sample_main():
 
         if args[0] == "Exception":
             # Raise a generic exception
-            raise Exception("crashed: %s" % args[1:])
+            raise RuntimeError("crashed: %s" % args[1:])
 
         assert args[0] != "AssertionError", "oops, something went wrong"
         if args[0] == "exit":
@@ -108,7 +108,7 @@ def test_crash(cli):
         cli.expect_failure(["Exception", "hello"], "this message shouldn't appear")
 
 
-def test_edge_cases(temp_folder, monkeypatch):
+def test_edge_cases(temp_folder):
     # Exercise dev folder determination code
     info = runez.system.DevInfo()
     info.tests_folder = "./bar/baz"
@@ -153,7 +153,7 @@ def test_script_invocations(cli):
         cli.exercise_main("failed-help")
 
 
-def test_success(cli, monkeypatch):
+def test_success(cli):
     cli.main = sample_main
 
     # Verify that project folder works properly


### PR DESCRIPTION
Enabled:
- PT flake8-pytest
- PYI flake8-pyi
- Q flake8-quotes
- RSE flake8-raise
- RUF ruff-specific
- SLOT flake8-slots
- T10 flake8-debugger
- TID flake8-tidy-imports
- TCH flake8-type-checking
- TD flake8-todos
- W pycodestyle warnings
