### PR TITLE
Find already scanned python installations by path

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+5.1.1 (2024-08-12)
+------------------
+
+* Find already scanned python installations by path
+
+
 5.1.0 (2024-02-28)
 ------------------
 

--- a/src/runez/ascii.py
+++ b/src/runez/ascii.py
@@ -5,14 +5,26 @@ from runez.system import flattened
 
 
 class AsciiAnimation:
-    """Contains a few progress spinner animation examples"""
+    """Progress spinner animations"""
 
     env_var = "SPINNER"  # Env var overriding which predefined spinner to use
     default = "dots"  # Default spinner to use
 
     @classmethod
     def available_names(cls, include_virtual=True):
-        """(list[str]): Available ascii animation names from this sample collection"""
+        """
+        Available ascii spinner animation names
+
+        Parameters
+        ----------
+        include_virtual : bool
+            If True, also include `random` and `off` (virtual names)
+
+        Returns
+        -------
+        List[str]
+            Available ascii animation names from this sample collection
+        """
         return sorted(k[3:] for k in dir(cls) if k.startswith("af_")) + (["random", "off"] if include_virtual else [])
 
     @classmethod
@@ -63,12 +75,19 @@ class AsciiAnimation:
     @classmethod
     def get_frames(cls, spec, default=None):
         """
-        Args:
-            spec (AsciiFrames | callable | str | None): What frame animation to use
-            default (AsciiFrames | callable | str | None): Default
+        Get frames from given spec, or default
 
-        Returns:
-            (AsciiFrames): First found: from env var, then given 'spec', then 'default, finally 'cls.default'
+        Parameters
+        ----------
+        spec : AsciiFrames or Callable or str or None
+            What frame animation to use
+        default : AsciiFrames or Callable or str or None
+            Default to use if `spec` is not usable
+
+        Returns
+        -------
+        AsciiFrames
+            First found: from env var, then given `spec`, then `default`, finally `cls.default`
         """
         if isinstance(spec, AsciiFrames):
             return spec
@@ -136,13 +155,16 @@ class AsciiAnimation:
 
 
 class AsciiFrames:
-    """Holds ascii animation frames, one-line animations of arbitrary size (should be playable in a loop for good visual effect)"""
-
     def __init__(self, frames, fps=10):
         """
-        Args:
-            frames: Frames composing the ascii animation
-            fps (int): Desired frames per second
+        Ascii animation frames, one-line animations of arbitrary size (should be playable in a loop for good visual effect).
+
+        Parameters
+        ----------
+        frames : AsciiFrames or Callable or str, optional
+            Frames composing the ascii animation
+        fps : int
+            Desired frames per second
         """
         self.frames = flattened(frames) or None
         self.fps = fps

--- a/src/runez/pyenv.py
+++ b/src/runez/pyenv.py
@@ -479,7 +479,7 @@ class PythonDepot:
             return spec
 
         if isinstance(spec, Path):
-            return PythonInstallation.from_path(spec, short_name=short(spec))
+            return self._from_path(spec)
 
         python = self._find_python(spec)
         if python is None:
@@ -490,10 +490,17 @@ class PythonDepot:
 
         return python
 
+    def _from_path(self, path: Path):
+        for p in self.available_pythons:
+            if p == path:
+                return p
+
+        return PythonInstallation.from_path(path, short_name=short(path))
+
     def _find_python(self, spec):
         if isinstance(spec, str):
             if spec.startswith(("~", ".", "/")) or "/" in spec or os.path.exists(spec):
-                return PythonInstallation.from_path(Path(resolved_path(spec)), short_name=short(spec))
+                return self._from_path(Path(resolved_path(spec)))
 
             elif spec == "invoker":
                 return self.invoker
@@ -817,6 +824,9 @@ class PythonInstallation:
         return self.representation()
 
     def __eq__(self, other):
+        if isinstance(other, Path):
+            return other == self.executable or other == self.real_exe
+
         return isinstance(other, PythonInstallation) and self.real_exe == other.real_exe
 
     def __lt__(self, other):

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -152,7 +152,7 @@ def test_depot_adhoc(temp_folder):
 
     mk_python("./some-path/bin/13.1.2")
     assert str(depot.find_python("some-path/bin/python13.1")) == "some-path/bin/python13.1 [13.1.2]"
-    assert str(depot.find_python("./some-path/")) == "./some-path/ [13.1.2]"
+    assert str(depot.find_python("./some-path/")) == "some-path [13.1.2]"
     assert str(depot.find_python(runez.to_path("some-path"))) == "some-path [13.1.2]"
     assert str(depot.find_python("some-path/bin/python")) == "some-path/bin/python [13.1.2]"
     assert str(depot.find_python("some-path/bin")) == "some-path/bin [13.1.2]"
@@ -171,6 +171,7 @@ def test_depot_folder(temp_folder):
     assert depot.locations[0].preferred_python is python
     assert depot.find_python("8.5") is python
     assert depot.find_python("8.5.6") is python
+    assert str(depot.find_python(".pyenv/versions/8.5.6/bin/python8.5")) == "python8.5 [8.5.6]"
     assert str(depot.find_python("8.5.7")) == "8.5.7 [not available]"
 
 


### PR DESCRIPTION
This will help find "canonical path" to python installations (instead of fully expanded symlink)