### PR TITLE
Isolate changes to env vars in tests, especially in `cli.run()`

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+5.2.1 (2024-10-11)
+------------------
+
+* Restore env vars in ``IsolatedLogSetup`` context manager
+
+
 5.2.0 (2024-09-18)
 ------------------
 


### PR DESCRIPTION
Code that modifies env vars can lead to subtle side effects from one test to another